### PR TITLE
Refactor(develop-watch-docker)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,15 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5173:5173"
+    develop:
+      watch:
+        - action: sync
+          path: ./frontend/src
+          target: /app/src
+          ignore:
+            - node_modules
+        - action: rebuild
+          path: ./frontend/package.json
   backend:
     build:
       context: ./backend


### PR DESCRIPTION
## Purporse
Aims to allow the dev team to work on the frontend in a better way, by enabling the hot reload in the frontend code

## What I've Done
-> adds the develop and watcher property in the frontend configuration on the docker compose file